### PR TITLE
fix: favicon of blogcard in dark mode

### DIFF
--- a/src/assets/styles/content-dark.scss
+++ b/src/assets/styles/content-dark.scss
@@ -66,10 +66,12 @@
         }
         .footer {
           color: #dadada;
-          .favicon {
-            img {
-              mix-blend-mode: multiply;  // nice!
-            }
+        }
+      }
+      .thumbnail.github + .content {
+        .favicon {
+          img {
+            mix-blend-mode: multiply;
           }
         }
       }


### PR DESCRIPTION
make sure that only github's domain to be black